### PR TITLE
Changed absolute to relative path in NetworkEngine_HL settings

### DIFF
--- a/Engine/NetworkEngine_HL/NetworkEngine_HL.vcxproj
+++ b/Engine/NetworkEngine_HL/NetworkEngine_HL.vcxproj
@@ -90,10 +90,10 @@
       <MinimalRebuild>false</MinimalRebuild>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)\Engine</AdditionalIncludeDirectories>
-      <ProgramDataBaseFileName>D:\Inline-Engine\Bin\Debug_x64\net_hl.pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(SolutionDir)Bin\Debug_x64\net_hl.pdb</ProgramDataBaseFileName>
     </ClCompile>
     <Link>
-      <ProgramDatabaseFile>E:\Inline-Engine\Bin\Debug_x64\net_hl.pdb</ProgramDatabaseFile>
+      <ProgramDatabaseFile>$(SolutionDir)Bin\Debug_x64\net_hl.pdb</ProgramDatabaseFile>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Replaced both `D:\Inline-Engine\` and `E:\Inline-Engine\` by `$(SolutionDir)`